### PR TITLE
BugFix: get_models_maxtoken_dict() will throw TypeError when the para…

### DIFF
--- a/llmx/utils.py
+++ b/llmx/utils.py
@@ -171,6 +171,9 @@ def load_config():
 
 
 def get_models_maxtoken_dict(models_list):
+    if not models_list:
+        return {}
+
     models_dict = {}
     for model in models_list:
         if "model" in model and "parameters" in model["model"]:


### PR DESCRIPTION
Default value of `models` in Class `OpenAITextGenerator` is None. 
The None `models` will cause the `get_models_maxtoken_dict()` fail
<img width="877" alt="image" src="https://github.com/victordibia/llmx/assets/22412942/638ec0bb-6c8a-49d0-80a3-c751e5dd4637">

<img width="1347" alt="image" src="https://github.com/victordibia/llmx/assets/22412942/9ccf9838-a244-4661-b120-a91f42ab2a98">
