### PR TITLE
Update OpenAITextGenerator to support latest openai package

### DIFF
--- a/llmx/generators/text/openai_textgen.py
+++ b/llmx/generators/text/openai_textgen.py
@@ -31,8 +31,6 @@ class OpenAITextGenerator(TextGenerator):
             openai.organization = organization
         if api_version:
             openai.api_version = api_version
-        if api_base:
-            openai.api_base = api_base
         if api_type:
             openai.api_type = api_type
 

--- a/llmx/version.py
+++ b/llmx/version.py
@@ -1,1 +1,2 @@
 VERSION = "0.0.18a"
+APP_NAME = "llmx"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 
 dependencies = [
     "pydantic",
-    "openai==0.28.1",  
+    "openai",
     "tiktoken",
     "diskcache",
     "cohere", 


### PR DESCRIPTION
This PR contains changes to support latest openai package in `OpenAITextGenerator` class , issue - https://github.com/microsoft/lida/issues/63

## Why this change is required
We are developing a project which requires lida (which is dependent on llmx) along with other packages like langchain and llama index , Since llmx doesn't support latest openai package and other libraries are dependent on latest version , there is an openai version conflict and we cannot downgrade openai version

## How this change has been tested
Manual testing has been done by using the latest openai version 