### PR TITLE
Added support for http_client,extra_headers and extra_query in openai

### DIFF
--- a/llmx/generators/text/openai_textgen.py
+++ b/llmx/generators/text/openai_textgen.py
@@ -1,4 +1,7 @@
-from typing import Union, List, Dict
+from typing import Union, List, Dict, Mapping
+
+import httpx
+
 from .base_textgen import TextGenerator
 from ...datamodel import Message, TextGenerationConfig, TextGenerationResponse
 from ...utils import cache_request, get_models_maxtoken_dict, num_tokens_from_messages
@@ -17,6 +20,10 @@ class OpenAITextGenerator(TextGenerator):
         api_version: str = None,
         azure_endpoint: str = None,
         model: str = None,
+        azure_deployment: str = None,
+        http_client: httpx.Client = None,
+        default_headers: Mapping[str, object] = None,
+        default_query: Mapping[str, object] = None,
         models: Dict = None,
     ):
         super().__init__(provider=provider)
@@ -32,6 +39,10 @@ class OpenAITextGenerator(TextGenerator):
             "organization": organization,
             "api_version": api_version,
             "azure_endpoint": azure_endpoint,
+            "azure_deployment": azure_deployment,
+            "http_client": http_client,
+            "default_headers": default_headers,
+            "default_query": default_query
         }
         # remove keys with None values
         self.client_args = {k: v for k,


### PR DESCRIPTION
This PR contains changes to support custom HTTP client, default headers and default queries in using OpenAITextGenerator.

## Why is this change required

We want to pass custom headers to our internal proxy layer which is built on top of AzureOpenAI for our internal audit and metrics. Currently this is not supported on llmx and subsequently, not available via lida. This change attempts to add support for a custom http_client along with additional default_headers and default_query parameters. 

## How is this tested

We have done an internal testing with our proxy layer. Sample code:

```
headers = {"X-Custom-Header": "Custom-Val"}
client = httpx.Client(headers=headers)

llm_inst = llm(provider="openai",  api_type="azure", azure_endpoint="https://openaiproxy.prod.walmart.com",
               api_key=api_key, api_version="2024-02-01", model="gpt-35-turbo", http_client=client)
config = TextGenerationConfig(n=1, temperature=0.2, max_tokens=100)

msgs = [
    {"role": "system", "content": "You are a helpful assistant that can explain concepts clearly to a 6 year old child."},
    {"role": "user", "content": "What is  gravity?"}
]
response = llm_inst.generate(messages=msgs, config=config)
```