### PR TITLE
[add] Added HTTP Client in OpenAI Chat Instance

### DIFF
--- a/llmx/generators/text/openai_textgen.py
+++ b/llmx/generators/text/openai_textgen.py
@@ -5,6 +5,7 @@ from ...utils import cache_request, get_models_maxtoken_dict, num_tokens_from_me
 import os
 from openai import AzureOpenAI, OpenAI
 from dataclasses import asdict
+import httpx
 
 
 class OpenAITextGenerator(TextGenerator):
@@ -18,6 +19,7 @@ class OpenAITextGenerator(TextGenerator):
         azure_endpoint: str = None,
         model: str = None,
         models: Dict = None,
+        http_client: httpx.Client = None,
     ):
         super().__init__(provider=provider)
         self.api_key = api_key or os.environ.get("OPENAI_API_KEY", None)
@@ -32,6 +34,7 @@ class OpenAITextGenerator(TextGenerator):
             "organization": organization,
             "api_version": api_version,
             "azure_endpoint": azure_endpoint,
+            "http_client": http_client
         }
         # remove keys with None values
         self.client_args = {k: v for k,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "google.auth",
     "typer",
     "pyyaml",
+    "httpx",
 ]
 optional-dependencies = {web = ["fastapi", "uvicorn"], transformers = ["transformers[torch]>=4.26","accelerate"]}
 


### PR DESCRIPTION
HTTP Client (httpx.Client) is necessary for a corporate based user to authenticate OpenAI Agent. This is already an acceptable parameter with OpenAI and does not break for users who do not provide the client. 

This will help the corporates to use your solution and other applications using llmx as dependancy. 