### PR TITLE
Add quantization config to HFTextGenerator

### DIFF
--- a/llmx/generators/text/hf_textgen.py
+++ b/llmx/generators/text/hf_textgen.py
@@ -1,6 +1,6 @@
 from typing import Dict, Union
 from dataclasses import asdict, dataclass
-from transformers import (AutoTokenizer, AutoModelForCausalLM, GenerationConfig)
+from transformers import (AutoTokenizer, AutoModelForCausalLM, GenerationConfig, BitsAndBytesConfig)
 import torch
 
 
@@ -99,7 +99,7 @@ class HFTextGenerator(TextGenerator):
         self.dialogue_type = kwargs.get("dialogue_type", "alpaca")
 
         self.model_name = kwargs.get("model", "uukuguy/speechless-llama2-hermes-orca-platypus-13b")
-        self.load_in_8bit = kwargs.get("load_in_8bit", False)
+        self.quantization_config = kwargs.get("quantization_config", BitsAndBytesConfig())
         self.trust_remote_code = kwargs.get("trust_remote_code", False)
         self.device = kwargs.get("device", self.get_default_device())
 
@@ -107,8 +107,11 @@ class HFTextGenerator(TextGenerator):
         self.tokenizer = AutoTokenizer.from_pretrained(
             self.model_name, trust_remote_code=self.trust_remote_code)
         self.model = AutoModelForCausalLM.from_pretrained(
-            self.model_name, device_map=device_map, load_in_8bit=self.load_in_8bit,
-            trust_remote_code=self.trust_remote_code)
+            self.model_name,
+            device_map=device_map,
+            quantization_config=self.quantization_config,
+            trust_remote_code=self.trust_remote_code,
+        )
         if not device_map:
             self.model.to(self.device)
         self.model.config.pad_token_id = self.tokenizer.pad_token_id

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "typer",
     "pyyaml",
 ]
-optional-dependencies = {web = ["fastapi", "uvicorn"], transformers = ["transformers[torch]>=4.26","accelerate"]}
+optional-dependencies = {web = ["fastapi", "uvicorn"], transformers = ["transformers[torch]>=4.26","accelerate", "bitsandbytes"]}
 
 dynamic = ["version"]
 


### PR DESCRIPTION
This PR adds a quantization_config option to HFTextGenerator to allow for 8bit or 4bit quantization, the latter not having been possible previously.

In addition, the previous argument setup will be deprecated in the future:

> The `load_in_4bit` and `load_in_8bit` arguments are deprecated and will be removed in the future versions. Please, pass a `BitsAndBytesConfig` object in `quantization_config` argument instead.

![image](https://github.com/user-attachments/assets/244b901d-2062-440e-9e46-d0dd471a6cbc)

The changes are in accordance with the HuggingFace docs: https://github.com/huggingface/transformers/blob/main/docs/source/en/quantization/bitsandbytes.md

> Now you can quantize a model by passing a `BitsAndBytesConfig` to [`~PreTrainedModel.from_pretrained`] method. This works for any model in any modality, as long as it supports loading with Accelerate and contains `torch.nn.Linear` layers.
> 
> Quantizing a model in 8-bit halves the memory-usage, and for large models, set `device_map="auto"` to efficiently use the GPUs available:
> 
> ```py
> from transformers import AutoModelForCausalLM, BitsAndBytesConfig
> 
> quantization_config = BitsAndBytesConfig(load_in_8bit=True)
> 
> model_8bit = AutoModelForCausalLM.from_pretrained(
>     "bigscience/bloom-1b7", 
>     quantization_config=quantization_config
> )
> ```
> 
